### PR TITLE
Report multiline syntax errors without throwing

### DIFF
--- a/example/multiline_error.coffee
+++ b/example/multiline_error.coffee
@@ -1,0 +1,7 @@
+#----------------------------------#
+# hello, my name is: SµNTtaX E®Rör #
+#----------------------------------#
+
+
+'this is very wrong. notice that the first line is''
+longer'

--- a/index.js
+++ b/index.js
@@ -20,7 +20,10 @@ function ParseError(error, src, file) {
     this.line = error.location.first_line + 1; // cs linenums are 0-indexed
     this.column = error.location.first_column + 1; // same with columns
 
-    var markerLen = 2 + error.location.last_column - error.location.first_column;
+    var markerLen = 2;
+    if(error.location.first_line === error.location.last_line) {
+        markerLen += error.location.last_column - error.location.first_column;
+    }
     this.annotated = [
         file + ':' + this.line,
         src.split('\n')[this.line - 1],

--- a/test/error.js
+++ b/test/error.js
@@ -4,6 +4,7 @@ var path = require('path');
 var fs = require('fs');
 
 var file = path.resolve(__dirname, '../example/error.coffee');
+var multilineFile = path.resolve(__dirname, '../example/multiline_error.coffee');
 var transform = path.join(__dirname, '..');
 
 test('transform error', function (t) {
@@ -18,5 +19,15 @@ test('transform error', function (t) {
         t.ok(error.column !== undefined, "error.column should be defined");
         t.equal(error.line, 5, "error should be on line 5");
         t.equal(error.column, 15, "error should be on column 15");
+    });
+});
+
+test('multiline transform error', function (t) {
+    t.plan(1);
+
+    var b = browserify([multilineFile]);
+    b.transform(transform);
+    b.bundle(function (error) {
+        t.ok(error !== undefined, "bundle should callback with an error");
     });
 });


### PR DESCRIPTION
For multiline errors, last_column can be less the first_column, throwing on invalid array constructor with negative length.

This fix just shows the marker at the line and column of the start of the error if it spans multiple lines.
