### PR TITLE
make sourceMaps optional with coffeeify#sourceMap(boolean)

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,8 +96,8 @@ function coffeeify(file) {
 coffeeify.compile = compile;
 coffeeify.isCoffee = isCoffee;
 coffeeify.isLiterate = isLiterate;
-coffeeify.options = function(options) {
-    sourceMap = options.sourceMap || sourceMap;
+coffeeify.sourceMap = function(bool) {
+    sourceMap = bool;
     return coffeeify
 }
 


### PR DESCRIPTION
Hi there!

This PR adds the ability to configure including inline coffeescript sourcemaps, currently enabled by default. We've found that browser support for debugging coffeescript is still spotty and sometimes it's just easier to work with the compiled Javascript.
