### PR TITLE
Prepend dot in README extension example

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -49,7 +49,7 @@ module.exports = require('./baz')(5)
 ```
 
 ```
-$ browserify -t coffeeify --extension=coffee foo.coffee > bundle.js
+$ browserify -t coffeeify --extension=".coffee" foo.coffee > bundle.js
 $ node bundle.js
 555
 ```


### PR DESCRIPTION
As of today, node-browserify is prepending a dot to the extensions option: https://github.com/substack/node-browserify/blob/master/index.js#L57

Using the `--extension` option without the dot throws error about `require` not finding modules.
