### PR TITLE
work around substack/insert-module-globals#29

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ function compile(file, data, callback) {
     var map = convert.fromJSON(compiled.v3SourceMap);
     map.setProperty('sources', [file]);
 
-    callback(null, compiled.js + '\n' + map.toComment());
+    callback(null, compiled.js + '\n' + map.toComment() + '\n');
 }
 
 function coffeeify(file) {


### PR DESCRIPTION
Coffeeify and Browserify don't play nice right now due to substack/insert-module-globals#29

There seems to be no downside to adding a newline after the sourcemap comment to work around it.
