### PR TITLE
make source maps optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var coffee = require('coffee-script');
+﻿var coffee = require('coffee-script');
 var through = require('through');
 var convert = require('convert-source-map');
 
@@ -46,7 +46,7 @@ function compile(file, data, callback) {
     var compiled;
     try {
         compiled = coffee.compile(data, {
-            sourceMap: true,
+            sourceMap: coffeeify.sourceMap,
             generatedFile: file,
             inline: true,
             bare: true,
@@ -61,10 +61,14 @@ function compile(file, data, callback) {
         return;
     }
 
-    var map = convert.fromJSON(compiled.v3SourceMap);
-    map.setProperty('sources', [file]);
-
-    callback(null, compiled.js + '\n' + map.toComment() + '\n');
+    if (coffeeify.sourceMap) {
+        var map = convert.fromJSON(compiled.v3SourceMap);
+        map.setProperty('sources', [file]);
+        callback(null, compiled.js + '\n' + map.toComment() + '\n');
+    } else {
+        callback(null, compiled + '\n');
+    }
+    
 }
 
 function coffeeify(file) {
@@ -90,5 +94,6 @@ function coffeeify(file) {
 coffeeify.compile = compile;
 coffeeify.isCoffee = isCoffee;
 coffeeify.isLiterate = isLiterate;
+coffeeify.sourceMap = true; // use source maps by default
 
 module.exports = coffeeify;

--- a/no-debug.js
+++ b/no-debug.js
@@ -1,0 +1,3 @@
+coffeeify = require('./index');
+coffeeify.sourceMap = false;
+module.exports = coffeeify;

--- a/test/bundle.js
+++ b/test/bundle.js
@@ -20,6 +20,25 @@ function bundle (file) {
             t.equal(msg, 555);
         }
     });
+    
+    test('bundle transform (no-debug)', function (t) {
+      t.plan(1);
+
+      var b = browserify();
+      b.add(__dirname + file);
+      b.transform(__dirname + '/../no-debug');
+      b.bundle(function (err, src) {
+        if (err) t.fail(err);
+        vm.runInNewContext(src, {
+          console: { log: log }
+        });
+      });
+
+      function log (msg) {
+        t.equal(msg, 555);
+      }
+    });
+    
 }
 
 bundle('/../example/foo.coffee');

--- a/test/no-debug.js
+++ b/test/no-debug.js
@@ -1,0 +1,14 @@
+var test = require('tap').test;
+
+test('sourceMap use', function (t) {
+
+  t.plan(2);
+
+  defaultCoffeeify = require(__dirname + '/..');
+  t.equal(defaultCoffeeify.sourceMap, true, "sourceMap is true by default");
+
+  noDebugCoffeeify = require(__dirname + '/../no-debug');
+  t.equal(noDebugCoffeeify.sourceMap, false, "sourceMap is false for no-debug");
+
+});
+

--- a/test/transform.js
+++ b/test/transform.js
@@ -5,11 +5,13 @@ var through   =  require('through');
 var convert   =  require('convert-source-map');
 var transform =  require('..');
 
-test('transform adds sourcemap comment', function (t) {
+test('transform adds sourcemap comment when sourceMap is true', function (t) {
     t.plan(1);
     var data = '';
+    
+    transform.sourceMap = true;
 
-    var file = path.join(__dirname, '../example/foo.coffee')
+    var file = path.join(__dirname, '../example/foo.coffee');
     fs.createReadStream(file)
         .pipe(transform(file))
         .pipe(through(write, end));
@@ -30,4 +32,24 @@ test('transform adds sourcemap comment', function (t) {
             'adds sourcemap comment including original source'
       );
     }
+});
+
+test('transform does not add sourcemap when sourceMap is false', function (t) {
+
+  t.plan(1);
+  var data = '';
+
+  transform.sourceMap = false;
+
+  var file = path.join(__dirname, '../example/foo.coffee');
+  fs.createReadStream(file)
+    .pipe(transform(file))
+    .pipe(through(write, end));
+
+  function write (buf) { data += buf }
+  function end () {
+    var sourceMap = convert.fromSource(data);
+    t.equal(sourceMap, null);
+  }
+
 });


### PR DESCRIPTION
Makes source maps optional:

```
browserify -t coffeeify/no-debug ...
```

Or:

```
var transform =  require('coffeeify');
transform.sourceMap = false;
```

Closes https://github.com/jnordberg/coffeeify/issues/12

One of the tests is failing and it's failing even before these changes. I couldn't understand why it fails. Can you take a look?

```
not ok test/transform.js ................................ 2/3
    Command: "C:\Program Files\nodejs\node.exe transform.js"
    TAP version 13
    not ok 1 adds sourcemap comment including original source
      ---
        file:   stream.js
        line:   79
        column: 10
        stack:
          - getCaller (F:\Tom\Code\GitHub\coffeeify\node_modules\tap\lib\tap-assert.js:418:17)
          - assert (F:\Tom\Code\GitHub\coffeeify\node_modules\tap\lib\tap-assert.js:21:16)
          - Function.equivalent (F:\Tom\Code\GitHub\coffeeify\node_modules\tap\lib\tap-assert.js:182:12)
          - Test._testAssert (F:\Tom\Code\GitHub\coffeeify\node_modules\tap\lib\tap-test.js:87:16)
          - Stream.end (F:\Tom\Code\GitHub\coffeeify\test\transform.js:23:11)
          - _end (F:\Tom\Code\GitHub\coffeeify\node_modules\through\index.js:65:9)
          - Stream.stream.end (F:\Tom\Code\GitHub\coffeeify\node_modules\through\index.js:74:5)
          - Stream.onend (stream.js:79:10)
          - Stream.EventEmitter.emit (events.js:117:20)
          - drain (F:\Tom\Code\GitHub\coffeeify\node_modules\through\index.js:34:23)
          - Stream.stream.queue.stream.push (F:\Tom\Code\GitHub\coffeeify\node_modules\through\index.js:45:5)
          - F:\Tom\Code\GitHub\coffeeify\index.js:88:14
          - compile (F:\Tom\Code\GitHub\coffeeify\index.js:67:5)
          - Stream.end (F:\Tom\Code\GitHub\coffeeify\index.js:85:5)
          - _end (F:\Tom\Code\GitHub\coffeeify\node_modules\through\index.js:65:9)
          - Stream.stream.end (F:\Tom\Code\GitHub\coffeeify\node_modules\through\index.js:74:5)
          - ReadStream.onend (_stream_readable.js:483:10)
          - ReadStream.g (events.js:180:16)
          - ReadStream.EventEmitter.emit (events.js:117:20)
          - _stream_readable.js:920:16
          - process._tickCallback (node.js:415:13)
          -
        found:
          version:        3
          file:           F:\Tom\Code\GitHub\coffeeify\example\foo.coffee
          sourceRoot:
          sources:
            - F:\Tom\Code\GitHub\coffeeify\example\foo.coffee
          names:
            -
          mappings:       AAAA,OAAO,CAAC,GAAR,CAAY,OAAA,CAAQ,UAAR,CAAZ,CAAA,CAAA
          sourcesContent:
            - console.log(require './bar.js')
        wanted:
          version:        3
          file:           F:\Tom\Code\GitHub\coffeeify\example\foo.coffee
          sourceRoot:
          sources:
            - F:\Tom\Code\GitHub\coffeeify\example\foo.coffee
          names:
            -
          mappings:       AAAA,OAAO,CAAC,GAAR,CAAY,OAAA,CAAQ,UAAR,CAAZ,CAAA,CAAA
          sourcesContent:
            - console.log(require './bar.js')
        diff:   |
          {
            "version" : 3,
            "file" : "F:\Tom\Code\GitHub\coffeeify\example\foo.coffee",
            "sourceRoot" : "",
            "sources" : [
              "F:\Tom\Code\GitHub\coffeeify\example\foo.coffee"
            ],
            "names" : [

            ],
            "mappings" : "AAAA,OAAO,CAAC,GAAR,CAAY,OAAA,CAAQ,UAAR,CAAZ,CAAA,CAAA",
            "sourcesContent" : [
              "console.log(require './bar.js')
          " // != "console.log(require './bar.js')
          "
            ]
          }
```
