### PR TITLE
sourceMap:'noCoffee'

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 var convert = require('convert-source-map');
 var path = require('path');
 var through = require('through2');
+var assign = require('object-assign')
 
 var filePattern = /\.((lit)?coffee|coffee\.md)$/;
 
@@ -69,6 +70,12 @@ function compile(filename, source, options, callback) {
         var basename = path.basename(filename);
         map.setProperty('file', basename.replace(filePattern, '.js'));
         map.setProperty('sources', [basename]);
+
+        if(options.sourceMap == 'noCoffee'){
+          //give me granular JS only
+          delete map.sourcemap.sourcesContent;
+          map.setProperty('mappings', '');
+        }
         callback(null, compiled.js + '\n' + map.toComment() + '\n');
     } else {
         callback(null, compiled + '\n');
@@ -87,15 +94,7 @@ function coffeeify(filename, options) {
         header: false
     };
 
-    for (var i = 0, keys = Object.keys(compileOptions); i < keys.length; i++) {
-        var key = keys[i], option = options[key];
-        if (typeof option !== 'undefined' && option !== null) {
-            if (option === 'false' || option === 'no' || option === '0') {
-                option = false;
-            }
-            compileOptions[key] = !!option;
-        }
-    }
+    assign(compileOptions, options);
 
     var chunks = [];
     function transform(chunk, encoding, callback) {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "coffee-script": "^1.10.0",
     "convert-source-map": "^1.1.2",
+    "object-assign": "4.0.1",
     "through2": "^2.0.0"
   },
   "devDependencies": {

--- a/test/transform.js
+++ b/test/transform.js
@@ -49,3 +49,29 @@ test('transform does not add sourcemap when sourceMap option is false', function
   }
 
 });
+
+test('transform adds sourcemap comment when sourceMap option is "noCoffee"', function (t) {
+    t.plan(1);
+    var data = '';
+
+    var file = path.join(__dirname, '../example/foo.coffee');
+    fs.createReadStream(file)
+        .pipe(transform(file, {sourceMap: 'noCoffee'}))
+        .pipe(through(write, end));
+
+    function write (buf) { data += buf }
+    function end () {
+        var sourceMap = convert.fromSource(data).toObject();
+
+        t.deepEqual(
+            sourceMap,
+            { version: 3,
+              file: 'foo.js',
+              sourceRoot: '',
+              sources: [ 'foo.coffee' ],
+              names: [],
+              mappings: ''},
+            'adds sourcemap comment including original source'
+      );
+    }
+});


### PR DESCRIPTION
Finally able to just see my JS without coffee in my debugger

This sourcemaps all the files as they did but removes all the coffee files for straight js debugging.

This is the way it was:
![screen shot 2016-03-02 at 11 59 28 pm](https://cloud.githubusercontent.com/assets/583593/13485167/d8c68a68-e0d2-11e5-81e0-6cac67ead7de.png)

Now when `sourceMap: 'noCoffee''`

![screen shot 2016-03-02 at 11 57 59 pm](https://cloud.githubusercontent.com/assets/583593/13485169/e2d3ee9c-e0d2-11e5-8abc-bbbd5e7971aa.png)

The crowd goes wild.
