### PR TITLE
Adding support for streamline _coffee extensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var convert = require('convert-source-map');
 var path = require('path');
 var through = require('through2');
 
-var filePattern = /\._?((lit)?coffee|coffee\.md)$/;
+var filePattern = /\.(_?(lit)?coffee|coffee\.md)$/;
 
 function isCoffee (file) {
     return filePattern.test(file);

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var convert = require('convert-source-map');
 var path = require('path');
 var through = require('through2');
 
-var filePattern = /\.((lit)?coffee|coffee\.md)$/;
+var filePattern = /\._?((lit)?coffee|coffee\.md)$/;
 
 function isCoffee (file) {
     return filePattern.test(file);


### PR DESCRIPTION
I'm using streamline-js to parse coffeescript. Extension is *._coffee instead of *.coffee.
Could you please add to main version?

Thx
